### PR TITLE
expose tables as public instead of private

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -251,9 +251,6 @@ public:
         name asset_ram_payer
     );
 
-
-private:
-
     TABLE collections_s {
         name             collection_name;
         name             author;
@@ -370,6 +367,7 @@ private:
     config_t       config       = config_t(get_self(), get_self().value);
     tokenconfigs_t tokenconfigs = tokenconfigs_t(get_self(), get_self().value);
 
+private:
 
     void internal_transfer(
         name from,


### PR DESCRIPTION
External contracts cannot implement with this interface if the table structures are private.

```c++
atomicassets::templates_t _templates( "atomicassets"_n, collection_name.value );
auto itr = _templates.find( template_id );
```

❌ ERROR message receive at compile:

```c++
error: 'templates_t' is a private member of 'atomicassets'
    atomicassets::templates_t _templates( "atomicassets"_n, collection_name.value );
```