### PR TITLE
Fix where Asset in RAM originally owned by "owner1" is minted for "owner2" and then fails on transfer to "owner3"

### DIFF
--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -1294,12 +1294,12 @@ void atomicassets::internal_transfer(
             });
         }
 
-        to_assets.emplace(asset_itr->ram_payer, [&](auto &_asset) {
+        to_assets.emplace(from, [&](auto &_asset) {
             _asset.asset_id = asset_itr->asset_id;
             _asset.collection_name = asset_itr->collection_name;
             _asset.schema_name = asset_itr->schema_name;
             _asset.template_id = asset_itr->template_id;
-            _asset.ram_payer = asset_itr->ram_payer;
+            _asset.ram_payer = from;
             _asset.backed_tokens = asset_itr->backed_tokens;
             _asset.immutable_serialized_data = asset_itr->immutable_serialized_data;
             _asset.mutable_serialized_data = asset_itr->mutable_serialized_data;


### PR DESCRIPTION
This was causing a missing auth of "owner1" due to ram-payer issue.

I have not investigated deeply but changing the RAM to "from" as in the source change made it work immediately.
If it's not a row size issue perhaps it's a secondary index increase issue. (or perhaps I was just using the contracts wrong. :) )